### PR TITLE
(#14) Add migration for bactracs_synced_at

### DIFF
--- a/db/migrate/20220701000001_bactracs_typo_correction.rb
+++ b/db/migrate/20220701000001_bactracs_typo_correction.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class BactracsTypoCorrection < ActiveRecord::Migration[5.2]
+  def change
+    if ActiveRecord::Base.connection.column_exists?(:spree_shipments, :backtracs_synced_at)
+      rename_column :spree_shipments, :backtracs_synced_at, :bactracs_synced_at
+    end
+  end
+end

--- a/lib/solidus_bactracs/version.rb
+++ b/lib/solidus_bactracs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusBactracs
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
* followup to #2 
* needed for community use of the gem.  'batteries included' DB model