### PR TITLE
ensure safe string return from xml method

### DIFF
--- a/lib/solidus_bactracs/api/request_runner.rb
+++ b/lib/solidus_bactracs/api/request_runner.rb
@@ -29,7 +29,7 @@ module SolidusBactracs
               Rails.logger.info({ event: 'success CreateRMA', rma: shipment.number, response: parse_rma_creation_response(rma_response, "Message")})
               shipment_synced(shipment)
               return true
-            elsif rma_exists?(rma_response)
+            elsif rma_exists?(rma_response) or rma_fail?(rma_response)
               return false
             else
               clear_cache
@@ -89,7 +89,7 @@ module SolidusBactracs
 
         raise RequestError.from_response(@response) unless @response # just try again for @retries?
         if "false" == parse_authentication_response(@response, "Result")
-          Rails.logger.warn({ event: 'bactracs auth failed', error: parse_authentication_response(@response, "Message")})
+          Rails.logger.error({ event: 'bactracs auth failed', error: parse_authentication_response(@response, "Message")})
           raise RequestError.from_response(@response)
         end
         sguid = parse_authentication_response(@response, "Message")
@@ -110,11 +110,19 @@ module SolidusBactracs
       end
 
       def rma_exists?(response)
-        if parse_rma_creation_response(response, "Message").match(/rma .* already exists/)
-          Rails.logger.warn({ event: 'bactracs failed CreateRMA', error: parse_rma_creation_response(response, "Message")})
+        if parse_rma_creation_response(response, "Message").match(/failed CreateRMA/)
+          Rails.logger.error({ event: 'bactracs failed CreateRMA', error: parse_rma_creation_response(response, "Message")})
           return true
         end
       end
+
+      def rma_fail?(response)
+        if parse_rma_creation_response(response, "Message").match(/rma .* already exists/)
+          Rails.logger.error({ event: 'bactracs failed CreateRMA', error: parse_rma_creation_response(response, "Message")})
+          return true
+        end
+      end
+
 
       def shipment_synced(shipment)
         shipment.update_attribute(:bactracs_synced_at, Time.zone.now)

--- a/lib/solidus_bactracs/api/shipment_serializer.rb
+++ b/lib/solidus_bactracs/api/shipment_serializer.rb
@@ -69,8 +69,9 @@ module SolidusBactracs
             end
           end
         end
-        Rails.logger.info(xml.to_s)
-        xml
+        # Rails.logger.info(xml.to_s)
+        @xml = xml.to_xml.sub(/<to_xml\/>$/,'')
+        return @xml
       end
 
       def line_items_xml(xml: nil, line_item: nil, variant: nil, order: nil)

--- a/lib/solidus_bactracs/console_harness.rb
+++ b/lib/solidus_bactracs/console_harness.rb
@@ -36,7 +36,7 @@ module SolidusBactracs
       # resp = @runner.call(:post, '/orders/createorders', [serialize(shipment)])
       resp = @runner.authenticated_call(shipment: shipment, serializer: @syncer.client.shipment_serializer)
       if resp
-        @cursor += 1
+        @cursor += 1 if (a_shipment == @shipments[@cursor] || shipment == @shipments[@cursor])
         return resp
       end
     ensure

--- a/lib/solidus_bactracs/version.rb
+++ b/lib/solidus_bactracs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidusBactracs
-  VERSION = '3.5.1'
+  VERSION = '3.5.2'
 end


### PR DESCRIPTION
for some reason, the XML builder started to append tags even for `to_s` and `inspect` calls.  Our code didn't call these, so it was either a rails implicit expression, or sentry inspection, or both. 

This built up a queue of ~116 unfinished syncs

[I have created a new logtrail alert to slack](https://papertrailapp.com/searches/178705546/edit), when these are failing

After merging this PR is needs to be built and merged to SC API, then released to main